### PR TITLE
Fix compilation bug for gcc version 8.3.0 (Debian 8.3.0-6)

### DIFF
--- a/libavcodec/mpegvideo.h
+++ b/libavcodec/mpegvideo.h
@@ -785,10 +785,10 @@ void ff_fix_long_mvs(MpegEncContext * s, uint8_t *field_select_table, int field_
                      int16_t (*mv_table)[2], int f_code, int type, int truncate);
 void ff_init_me(MpegEncContext *s);
 int ff_pre_estimate_p_frame_motion(MpegEncContext * s, int mb_x, int mb_y);
-inline int ff_epzs_motion_search(MpegEncContext * s, int *mx_ptr, int *my_ptr,
+extern inline int ff_epzs_motion_search(MpegEncContext * s, int *mx_ptr, int *my_ptr,
                              int P[10][2], int src_index, int ref_index, int16_t (*last_mv)[2],
                              int ref_mv_scale, int size, int h);
-inline int ff_get_mb_score(MpegEncContext * s, int mx, int my, int src_index,
+extern inline int ff_get_mb_score(MpegEncContext * s, int mx, int my, int src_index,
                                int ref_index, int size, int h, int add_rate);
 
 /* mpeg12.c */


### PR DESCRIPTION
When compiling on Debian Buster ( gcc version 8.3.0 (Debian 8.3.0-6) ), ld fails with :
>/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/libavcodec.a(motion_est.o): in function `ff_estimate_motion_b':
/tmp/amv-ffmpeg/libavcodec/motion_est.c:1556: undefined reference to `ff_epzs_motion_search'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/libavcodec.a(motion_est.o): in function `direct_search':
/tmp/amv-ffmpeg/libavcodec/motion_est.c:1819: undefined reference to `ff_epzs_motion_search'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/libavcodec.a(motion_est.o): in function `ff_estimate_p_frame_motion':
/tmp/amv-ffmpeg/libavcodec/motion_est.c:1273: undefined reference to `ff_epzs_motion_search'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/libavcodec.a(motion_est.o): in function `ff_pre_estimate_p_frame_motion':
/tmp/amv-ffmpeg/libavcodec/motion_est.c:1473: undefined reference to `ff_epzs_motion_search'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/libavcodec.a(snow.o): in function `encode_q_branch':
/tmp/amv-ffmpeg/libavcodec/snow.c:1892: undefined reference to `ff_epzs_motion_search'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/snow.c:1901: undefined reference to `ff_get_mb_score'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/snow.c:1892: undefined reference to `ff_epzs_motion_search'
/usr/bin/ld: /tmp/amv-ffmpeg/libavcodec/snow.c:1901: undefined reference to `ff_get_mb_score'
collect2: error: ld returned 1 exit status

Adding extern to inline functions ff_epzs_motion_search and ff_get_mb_score in libavcodec/mpegvideo.h declarations seems to solve the problem.